### PR TITLE
Restore the `mageekguyatoumxmlassertersnodes::parent()` method

### DIFF
--- a/classes/asserters/nodes.php
+++ b/classes/asserters/nodes.php
@@ -49,7 +49,7 @@ class nodes extends asserter
                 return $this->generator->__call('integer', array(count($this->valueIsSet()->data)));
 
             case 'parent':
-                return $this->fromIsSet()->from;
+                return $this->parent();
 
             default:
                 throw new exceptions\logic(sprintf($this->getLocale()->_('Invalid asserter name %s'), $asserter));
@@ -105,5 +105,10 @@ class nodes extends asserter
         }
 
         return $this;
+    }
+
+    public function parent()
+    {
+        return $this->fromIsSet()->from;
     }
 }


### PR DESCRIPTION
Keeping this method will allow users to use both `->parent()` and `->parent`
in their code.
