### PR TITLE
add pass on xml assertion

### DIFF
--- a/classes/asserters/node.php
+++ b/classes/asserters/node.php
@@ -18,6 +18,8 @@ class node extends asserter
             $this->fail(sprintf($this->getLocale()->_('%s is not a valid XML'), $value));
         }
 
+        $this->pass();
+
         return $this;
     }
 

--- a/tests/units/classes/asserters/node.php
+++ b/tests/units/classes/asserters/node.php
@@ -32,6 +32,18 @@ class node extends atoum\test
             ;
     }
 
+    public function test_set_with_only_xml_assert()
+    {
+        $this
+            ->if($asserter = new SUT())
+                ->and($asserter->setWithTest(new self))
+                ->and($asserter->setWith("<?xml version=\"1.0\"?><root></root>"))
+            ->then
+                ->integer($asserter->getTest()->getScore()->getAssertionNumber())
+                    ->isEqualTo(1)
+        ;
+    }
+
     public function test_no_value_given()
     {
         $this


### PR DESCRIPTION
on atoum if I do something like this:
```
$this->string('mystring');
```
the score will be incremented and, if there is only that in the method
the result of the test will not be void.

When I use the extension to check if my serialize has worked (with without
checking if xml is valid against a schema, just to the if there is no error
(like adding directy a "&" in the xml without pass it by htmlspecialchars)),
the result of the test tells me that there is void test methods).

For example a method with just:
```
$this->xml("<?xml version=\"1.0\"?><root></root>");
```

Adding a call to pass in the setValue avoids that.