### PR TITLE
Move to Atoum 3.0 and enable PHP7.1 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - nightly
   - hhvm
   - hhvm-nightly
@@ -14,6 +15,9 @@ env:
     - COMPOSER_PREFER="--prefer-lowest"
 
 matrix:
+  exclude:
+    - php: 7.1
+      env: COMPOSER_PREFER="--prefer-lowest"
   allow_failures:
     - php: nightly
     - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "atoum/atoum": "^2.8"
+        "atoum/atoum": "^2.8 || ^3.0"
     },
     "require-dev": {
         "atoum/praspel-extension": "~0.16",
@@ -23,5 +23,10 @@
             "mageekguy\\atoum\\xml\\": "classes"
         },
         "files": ["autoloader.php"]
+    },
+    "scripts": {
+        "test": "atoum --test-ext",
+        "cbf": "phpcbf --standard=phpcs.xml .",
+        "cs": "phpcs --standard=phpcs.xml ."
     }
 }


### PR DESCRIPTION
For the moment prefer-lowest is disable on PHP7.1 because atoum 2.8 Is not compatible with this version…