### PR TITLE
fixes support for atoum 4.x

### DIFF
--- a/autoloader.php
+++ b/autoloader.php
@@ -1,10 +1,14 @@
 <?php
 
-namespace mageekguy\atoum\xml;
+namespace atoum\atoum\xml;
 
-use mageekguy\atoum;
+if (class_exists("\atoum\atoum\autoloader")) {
+    $classname = "\atoum\atoum\autoloader";
+} else {
+    $classname = "\mageekguy\atoum\autoloader";
+}
 
-atoum\autoloader::get()
+$autoloader = call_user_func($classname . '::get')
     ->addNamespaceAlias('atoum\xml', __NAMESPACE__)
     ->addDirectory(__NAMESPACE__, __DIR__ . DIRECTORY_SEPARATOR . 'classes');
 ;

--- a/classes/asserters/node.php
+++ b/classes/asserters/node.php
@@ -2,8 +2,8 @@
 
 namespace mageekguy\atoum\xml\asserters;
 
-use mageekguy\atoum\asserter;
-use mageekguy\atoum\exceptions;
+use atoum\atoum\asserter;
+use atoum\atoum\exceptions;
 
 class node extends asserter
 {

--- a/classes/asserters/nodes.php
+++ b/classes/asserters/nodes.php
@@ -2,8 +2,8 @@
 
 namespace mageekguy\atoum\xml\asserters;
 
-use mageekguy\atoum\asserter;
-use mageekguy\atoum\exceptions;
+use atoum\atoum\asserter;
+use atoum\atoum\exceptions;
 
 class nodes extends asserter
 {

--- a/classes/asserters/schema.php
+++ b/classes/asserters/schema.php
@@ -2,8 +2,8 @@
 
 namespace mageekguy\atoum\xml\asserters;
 
-use mageekguy\atoum\asserter;
-use mageekguy\atoum\exceptions;
+use atoum\atoum\asserter;
+use atoum\atoum\exceptions;
 
 class schema extends asserter
 {

--- a/classes/extension.php
+++ b/classes/extension.php
@@ -1,10 +1,10 @@
 <?php
 namespace mageekguy\atoum\xml;
 
-use mageekguy\atoum;
-use mageekguy\atoum\observable;
-use mageekguy\atoum\runner;
-use mageekguy\atoum\test;
+use atoum\atoum;
+use atoum\atoum\observable;
+use atoum\atoum\runner;
+use atoum\atoum\test;
 
 class extension implements atoum\extension
 {


### PR DESCRIPTION
following https://github.com/shulard/atoum-xml-extension/pull/8

since 4.0.0
cf https://github.com/atoum/atoum/blob/main/CHANGELOG.md#400---2020-11-21

the namespace `mageekguy\atoum` has been removed.

> #852 Rename namespace \mageekguy\atoum to \atoum\atoum (@Grummfy)

The related Pull Request is : https://github.com/atoum/atoum/pull/852