### PR TITLE
fixes another error when moving to atoum 4

### DIFF
--- a/classes/extension.php
+++ b/classes/extension.php
@@ -36,7 +36,7 @@ class extension implements atoum\extension
             'xml',
             function ($xml = null, $depth = null, $options = null) use ($test, & $asserter) {
                 if ($asserter === null) {
-                    $asserter = new atoum\xml\asserters\node($test->getAsserterGenerator());
+                    $asserter = new \mageekguy\atoum\xml\asserters\node($test->getAsserterGenerator());
                 }
                 if (null === $xml) {
                     throw new atoum\exceptions\logic("XML is undefined");
@@ -51,7 +51,7 @@ class extension implements atoum\extension
             'html',
             function ($html = null, $depth = null, $options = null) use ($test, & $asserter) {
                 if ($asserter === null) {
-                    $asserter = new atoum\xml\asserters\node($test->getAsserterGenerator());
+                    $asserter = new \mageekguy\atoum\xml\asserters\node($test->getAsserterGenerator());
                 }
                 if (null === $html) {
                     throw new atoum\exceptions\logic("HTML is undefined");


### PR DESCRIPTION
with this all of my test suites works with php 7.3 and atoum 4.x

the namespace needed to change because the xml plugin is on the \mageekguy\atoum namespace and the mageekguy\atoum is not imported anymore.